### PR TITLE
centerTypeの名前不一致対応

### DIFF
--- a/data/centerTypes.js
+++ b/data/centerTypes.js
@@ -8,7 +8,7 @@ const centerTypes = {
     { id: "NF", name: "居宅訪問型保育", value: "居宅訪問型保育" },
     { id: "NG", name: "千葉市認可保育園", value: "認可外保育所" },
     { id: "NH", name: "幼稚園", value: "幼稚園" },
-    { id: "NI", name: "認可外保育園", value: "認可外保育所" }
+    { id: "NI", name: "認可外保育園", value: "認可外保育施設" }
   ],
   afterSchool: [
     { id: "AA", name: "子どもルーム", value: "子どもルーム" }


### PR DESCRIPTION
centerTypeの判定において名前不一致で、一覧表示時にエラーが発生していた箇所を修正
×認可外保育所
〇認可外保育施設