### PR TITLE
市原市など、区がnullの時は非表示にする対応

### DIFF
--- a/pages/maps/index.vue
+++ b/pages/maps/index.vue
@@ -296,7 +296,7 @@ export default {
             "address",
             properties.prefecture +
             properties.city +
-            properties.ward +
+            (properties.ward !== 'null' ? properties.ward : '') +
             properties.address
           );
 

--- a/store/center/mutations.js
+++ b/store/center/mutations.js
@@ -44,7 +44,7 @@ function generateType(item) {
 }
 
 function fullAddress(item) {
-  return `${item.prefecture}${item.city}${item.ward}${item.address}`
+  return `${item.prefecture}${item.city}${item.ward !== null ? item.ward : ''}${item.address}`
 }
 
 function extendProps(item) {


### PR DESCRIPTION
[Trello](https://trello.com/c/03BghxoQ/153-%E4%BD%8F%E6%89%80%E3%81%AB-null-%E3%81%A8%E8%A1%A8%E7%A4%BA%E3%81%95%E3%82%8C%E3%82%8B)

### 対応
`ward(区) `が`null`の時、`''`を設定

### 動作確認画面
一覧画面
地図表示上の詳細情報(dialog)
施設詳細画面
お気に入り画面