### PR TITLE
開園時間の名称変更

### DIFF
--- a/components/nurseries/Summary.vue
+++ b/components/nurseries/Summary.vue
@@ -8,7 +8,7 @@
     </v-list-item>
     <v-list-item>
       <v-list-item-content>
-        <v-list-item-subtitle>開園時間</v-list-item-subtitle>
+        <v-list-item-subtitle>受入時間</v-list-item-subtitle>
         <v-list-item-title>{{ businessHours }}</v-list-item-title>
       </v-list-item-content>
     </v-list-item>

--- a/pages/maps/index.vue
+++ b/pages/maps/index.vue
@@ -35,7 +35,7 @@
             </v-list-item>
             <v-list-item>
               <v-list-item-content>
-                <v-list-item-title>時間</v-list-item-title>
+                <v-list-item-title>受入時間</v-list-item-title>
                 <v-list-item-subtitle>
                   {{ dialogData.start_time }}〜{{ dialogData.end_time }}
                 </v-list-item-subtitle>


### PR DESCRIPTION
学童対応を行った結果「開園時間」では名称が不適切という指摘があり「受入時間」に変更
- 詳細画面
<img width="288" alt="SnapCrab_NoName_2020-10-18_15-24-26_No-00" src="https://user-images.githubusercontent.com/3695706/96360318-1b226d00-1157-11eb-908c-fa9432fb39f8.png">

- 地図画面のポップアップ、ダイアログ
<img width="270" alt="SnapCrab_NoName_2020-10-18_15-24-8_No-00" src="https://user-images.githubusercontent.com/3695706/96360320-22497b00-1157-11eb-9c11-1e37fa54704c.png">
