### PR TITLE
マップの詳細画面の改善

### DIFF
--- a/data/centerTypes.js
+++ b/data/centerTypes.js
@@ -1,17 +1,23 @@
+/*
+ name: アプリ上の表示名
+ value: API 上の定義値
+ mapCategory: マップ上のカテゴリ。アイコンの出し分けに使用
+ */
+
 const centerTypes = {
   nursery: [
-    { id: "NA", name: "認可保育園", value: "保育園" },
-    { id: "NB", name: "認定こども園", value: "認定こども園" },
-    { id: "NC", name: "小規模保育", value: "小規模保育事業" },
-    { id: "ND", name: "家庭的保育", value: "家庭的保育事業" },
-    { id: "NE", name: "事業所内保育", value: "事業所内保育事業" },
-    { id: "NF", name: "居宅訪問型保育", value: "居宅訪問型保育" },
-    { id: "NG", name: "千葉市認可保育園", value: "認可外保育所" },
-    { id: "NH", name: "幼稚園", value: "幼稚園" },
-    { id: "NI", name: "認可外保育園", value: "認可外保育所" }
+    { id: "NA", name: "認可保育園", value: "保育園", mapCategory: "保育園" },
+    { id: "NB", name: "認定こども園", value: "認定こども園", mapCategory: "こども園" },
+    { id: "NC", name: "小規模保育", value: "小規模保育事業", mapCategory: "保育園" },
+    { id: "ND", name: "家庭的保育", value: "家庭的保育事業", mapCategory: "保育園" },
+    { id: "NE", name: "事業所内保育", value: "事業所内保育事業", mapCategory: "保育園" },
+    { id: "NF", name: "居宅訪問型保育", value: "居宅訪問型保育", mapCategory: "保育園" },
+    { id: "NG", name: "千葉市認可保育園", value: "認可外保育所", mapCategory: "保育園" },
+    { id: "NH", name: "幼稚園", value: "幼稚園", mapCategory: "幼稚園" },
+    { id: "NI", name: "認可外保育園", value: "認可外保育所", mapCategory: "保育園" }
   ],
   afterSchool: [
-    { id: "AA", name: "子どもルーム", value: "子どもルーム" }
+    { id: "AA", name: "子どもルーム", value: "子どもルーム", mapCategory: "子どもルーム" }
   ]
 }
 

--- a/data/mapCategories.js
+++ b/data/mapCategories.js
@@ -1,0 +1,8 @@
+const mapCategories = [
+  { name: "幼稚園", icon: "icon1" },
+  { name: "保育園", icon: "icon2" },
+  { name: "こども園", icon: "icon3" },
+  { name: "子どもルーム", icon: "icon4" }
+]
+
+export default mapCategories

--- a/store/center/mutations.js
+++ b/store/center/mutations.js
@@ -34,12 +34,11 @@ function generateTags(item) {
   return tags
 }
 
-function generateType(item) {
+function detectType(item) {
   if (item.nursery) {
-    const type = _.find(centerTypes.nursery, { value: item.nursery.facility.nurseryType })
-    return type.name
+    return _.find(centerTypes.nursery, { value: item.nursery.facility.nurseryType })
   } else {
-    return _.first(centerTypes.afterSchool).name
+    return _.first(centerTypes.afterSchool)
   }
 }
 
@@ -48,7 +47,9 @@ function fullAddress(item) {
 }
 
 function extendProps(item) {
-  item.type = generateType(item)
+  const type = detectType(item)
+  item.type = type.name
+  item.mapCategory = type.mapCategory
   item.tags = generateTags(item)
   item.fullAddress = fullAddress(item)
   return item
@@ -91,6 +92,7 @@ export default {
   UPDATE_MAP_HISTORY_ZOOM(state, zoom){
     state.mapHistory.zoom = zoom;
   },
+
   UPDATE_MAP_HISTORY_CENTER(state, center){
     state.mapHistory.center = center;
   }


### PR DESCRIPTION
## 対応内容

マップの詳細画面を以下のように変更しました。

* ツールバーに、施設名を表示するのをやめて、Card 側に持っていきました。
* ツールバーにお気に入りのインターフェイスを移動しました。
* 受入時間は、データがない施設もあるので、タグを表示するように変更しました。

また、マップ上に表示されない施設がある件も修正されていると思うので、確認ください。

## 変更後画面

<img width="351" alt="Screen Shot 2020-11-09 at 9 52 50" src="https://user-images.githubusercontent.com/614339/98489452-5d7c2d00-2271-11eb-9690-ce1e457deaa2.png">
